### PR TITLE
feat: prepare package for public npm publishing

### DIFF
--- a/.changeset/make-package-public.md
+++ b/.changeset/make-package-public.md
@@ -1,0 +1,11 @@
+---
+'changelog-github-custom': minor
+---
+
+feat: prepare package for public npm publishing
+
+- Added package metadata including description, author, and keywords
+- Configured package as public with proper npm publish settings
+- Added repository information
+- Specified main entry point and exports
+- Defined files to be included in the published package

--- a/package.json
+++ b/package.json
@@ -1,8 +1,36 @@
 {
   "name": "changelog-github-custom",
   "version": "1.1.0",
+  "description": "Custom GitHub changelog generator for Changesets",
+  "keywords": [
+    "changelog",
+    "changesets",
+    "github",
+    "release"
+  ],
+  "author": "Marc Tremblay",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapientpants/changelog-github-custom.git"
+  },
+  "private": false,
   "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "packageManager": "pnpm@10.15.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
## Summary
- Configured package.json for public npm publishing
- Added necessary metadata including description, author, and keywords
- Set up proper publishing configuration and repository information

## Changes
- Added package metadata (description, author, keywords, license)
- Configured package as public with npm publish settings
- Specified main entry point and exports
- Defined files to be included in published package
- Created changeset for version bump

## Test plan
- [x] All existing tests pass
- [x] Linting checks pass
- [x] Package builds successfully
- [ ] After merge, package can be published to npm

🤖 Generated with [Claude Code](https://claude.ai/code)