### PR TITLE
fix: add dual module support (ESM + CommonJS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
   },
   "private": false,
   "type": "module",
-  "main": "./dist/src/changelog-custom.js",
+  "main": "./dist/cjs/changelog-custom.js",
+  "module": "./dist/esm/changelog-custom.js",
+  "types": "./dist/types/changelog-custom.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/changelog-custom.d.ts",
-      "import": "./dist/src/changelog-custom.js"
+      "types": "./dist/types/changelog-custom.d.ts",
+      "import": "./dist/esm/changelog-custom.js",
+      "require": "./dist/cjs/changelog-custom.js",
+      "default": "./dist/esm/changelog-custom.js"
     }
   },
   "files": [
@@ -38,7 +42,10 @@
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput",
     "start": "node dist/index.js",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "pnpm build:clean && pnpm build:esm && pnpm build:cjs",
+    "build:clean": "rimraf dist",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:watch": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:watch": "tsc -p tsconfig.json --noEmit --watch",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist/cjs",
+    "declaration": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "**/*.spec.ts", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds dual module support to enable both CommonJS (`require()`) and ESM (`import`) usage
- Fixes compatibility with changesets which requires CommonJS format
- Maintains backward compatibility for ESM consumers

## Changes
- Created separate TypeScript build configurations for ESM and CommonJS outputs
- Updated package.json exports to properly support both module formats
- Modified build scripts to generate both dist/esm and dist/cjs directories
- Type definitions are now generated in dist/types

## Test plan
- [x] Build completes successfully with `pnpm build`
- [x] CommonJS output verified (uses `exports` and `"use strict"`)
- [x] ESM output verified (uses `import` statements)
- [x] All tests pass
- [x] Linting and formatting checks pass

## Context
This fix addresses the issue where changesets was unable to load the changelog formatter because it uses `require()` internally, while the package was previously ESM-only.

🤖 Generated with [Claude Code](https://claude.ai/code)