### PR TITLE
fix(ci): handle skipped dependencies in create-release job

### DIFF
--- a/.changeset/fix-release-creation-skipped-jobs.md
+++ b/.changeset/fix-release-creation-skipped-jobs.md
@@ -1,0 +1,7 @@
+---
+'changelog-github-custom': patch
+---
+
+Fix GitHub release creation when Docker build is disabled
+
+The create-release job was blocked when the docker job was skipped due to ENABLE_DOCKER_RELEASE not being set. Updated the conditional to properly handle skipped dependencies, allowing releases to be created even when optional build jobs (docker/npm) are disabled.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,7 +280,12 @@ jobs:
   create-release:
     name: Create GitHub Release
     needs: [build, docker, npm]
-    if: needs.build.outputs.changed == 'true'
+    # Run if build succeeded AND docker/npm either succeeded or were skipped
+    if: |
+      needs.build.outputs.changed == 'true' &&
+      !cancelled() &&
+      (needs.docker.result == 'success' || needs.docker.result == 'skipped') &&
+      (needs.npm.result == 'success' || needs.npm.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       released: ${{ steps.release.outputs.released }}


### PR DESCRIPTION
## Problem

The Main workflow was not creating GitHub releases even though version bumps and tags were being created successfully. For example, v1.2.6 was tagged but no GitHub release was published.

### Root Cause

The `create-release` job depends on three jobs:
```yaml
needs: [build, docker, npm]
if: needs.build.outputs.changed == 'true'
```

However, the `docker` and `npm` jobs have conditional execution:
- `docker` only runs if `vars.ENABLE_DOCKER_RELEASE == 'true'`
- `npm` only runs if `vars.ENABLE_NPM_RELEASE == 'true'`

When `ENABLE_DOCKER_RELEASE` is not set (current state), the docker job is skipped, but the `create-release` job's condition doesn't account for skipped dependencies. This causes the release creation to never execute.

## Solution

Updated the `create-release` job's conditional to properly handle skipped dependencies:

```yaml
if: |
  needs.build.outputs.changed == 'true' &&
  !cancelled() &&
  (needs.docker.result == 'success' || needs.docker.result == 'skipped') &&
  (needs.npm.result == 'success' || needs.npm.result == 'skipped')
```

This allows the release to be created when:
- Build succeeds with version changes
- Docker/npm jobs either succeed OR are skipped (disabled)
- Workflow is not cancelled

## Testing

After merging, the next version bump should successfully create a GitHub release even with Docker builds disabled.

## Related

- Missing release for v1.2.6 (tag exists but no GitHub release)
- Repository variable `ENABLE_DOCKER_RELEASE` is not set
- Repository variable `ENABLE_NPM_RELEASE` is set to `true`